### PR TITLE
Fix IPS patch importing skipping the "Unselected ROM" entry

### DIFF
--- a/script/app.js
+++ b/script/app.js
@@ -402,7 +402,7 @@ const app = new Vue({
       while (index < buffer.length) {
         if (state === 'offset') {
           const o = buffer.slice(index, index + 3);
-          const offsetStr = parseInt(`${o[0].toString(16)}${o[1].toString(16)}${o[2].toString(16)}`, 16);
+          const offsetStr = parseInt(o.map(n => n.toString(16).padStart(2, '0')).join(''), 16);
           temp.offset = offsetStr.toString(16).toUpperCase();
           index += 4;
           state = 'length';


### PR DESCRIPTION
`offsetStr` will be incorrect when the second or third byte value is < 16 (that is, results in a hex string with only a single digit).

This becomes an issue due to the [predefined offset `0x6A08`](https://github.com/orangeglo/everdrive-gba-editor/blob/2c645312e5410bebedff1854fd3781a7ce67c926/script/app.js#L16) being read as the [single byte `0x8`](https://github.com/orangeglo/everdrive-gba-editor/blob/2c645312e5410bebedff1854fd3781a7ce67c926/script/app.js#L404) and [converted to a hex string](https://github.com/orangeglo/everdrive-gba-editor/blob/2c645312e5410bebedff1854fd3781a7ce67c926/script/app.js#L405C81-L405C98) without adding a padding zero. In other words, the array `[0, 106, 8]` ends up as the number `1704` (`0x6A8`) rather than `27144` (`0x6A08`). It is then skipped when the [callback `valToState[d.offset]`](https://github.com/orangeglo/everdrive-gba-editor/blob/2c645312e5410bebedff1854fd3781a7ce67c926/script/app.js#L489) evaluates to `undefined` and is never called.

This fix also adds an additional `0` to the first byte value `0x6` which is ignored by `parseInt` and does not change the value.